### PR TITLE
Update workflow to node 24

### DIFF
--- a/.github/workflows/deploy-editor.yml
+++ b/.github/workflows/deploy-editor.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -36,7 +36,7 @@ jobs:
         run: npm run build:docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # to be updated
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
`actions/deploy-pages@v4` yet to be updated. Node 20 support ends on 2 June 2026.